### PR TITLE
Add Box Border Support for Various Pin Box Decorations in otpPinFieldDecoration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,20 @@ feat: Add support for custom border colors and width in OTP pin field
 - Added ability to customize border colors using defaultFieldBorderColor and activeFieldBorderColor properties.
 - Introduced fieldBorderWidth property to set the width of the border.
 - Updated documentation to guide users on how to achieve custom border effects.
-- 
+
 ## [1.2.7+1] -Release
 - Documents updated.
+
+## [1.2.8] - 2024-07-03
+
+### Added
+- Box border support for `defaultPinBoxDecoration`, `roundedPinBoxDecoration`, and `custom` in `otpPinFieldDecoration`.
+- Enhanced customization options for OTP pin fields, including border radius and box shadow properties.
+
+### Fixed
+- Clarified the usage of `borderRadius` property with `otpPinFieldDecoration.custom` to avoid confusion when using `underlinedPinBoxDecoration`.
+
+### Updated
+- Updated documentation and example code to demonstrate new features and proper usage of custom decorations.
+
+

--- a/lib/src/otp_pin_field_state.dart
+++ b/lib/src/otp_pin_field_state.dart
@@ -280,6 +280,7 @@ class OtpPinFieldState extends State<OtpPinField>
     Gradient? fieldBorderGradient;
     BoxDecoration boxDecoration;
     BoxDecoration? foregroundBoxDecoration;
+    List<BoxShadow>? boxShadow;
 
     Widget showCursorWidget() => widget.showCursor!
         ? _shouldHighlight(i)
@@ -297,6 +298,13 @@ class OtpPinFieldState extends State<OtpPinField>
                     Colors.transparent)
             ? widget.otpPinFieldStyle!.filledFieldBorderColor
             : widget.otpPinFieldStyle!.defaultFieldBorderColor;
+
+    boxShadow = widget.highlightBorder && _shouldHighlight(i)
+        ? widget.otpPinFieldStyle!.activeFieldBoxShadow
+        : (pinsInputed[i].isNotEmpty &&
+                widget.otpPinFieldStyle?.filledFieldBoxShadow != null)
+            ? widget.otpPinFieldStyle!.filledFieldBoxShadow
+            : widget.otpPinFieldStyle!.defaultFieldBoxShadow;
     fieldBackgroundColor = widget.highlightBorder && _shouldHighlight(i)
         ? widget.otpPinFieldStyle!.activeFieldBackgroundColor
         : (pinsInputed[i].isNotEmpty &&
@@ -305,14 +313,17 @@ class OtpPinFieldState extends State<OtpPinField>
             ? widget.otpPinFieldStyle!.filledFieldBackgroundColor
             : widget.otpPinFieldStyle!.defaultFieldBackgroundColor;
 
-    fieldBorderGradient = widget.highlightBorder &&
-            _shouldHighlight(i) &&
-            widget.otpPinFieldStyle?.activeFieldBorderGradient != null
-        ? widget.otpPinFieldStyle!.activeFieldBorderGradient
-        : (pinsInputed[i].isNotEmpty &&
-                widget.otpPinFieldStyle?.filledFieldBorderGradient != null)
-            ? widget.otpPinFieldStyle!.filledFieldBorderGradient
-            : widget.otpPinFieldStyle?.defaultFieldBorderGradient;
+    fieldBorderGradient = widget.otpPinFieldDecoration ==
+            OtpPinFieldDecoration.underlinedPinBoxDecoration
+        ? null
+        : widget.highlightBorder &&
+                _shouldHighlight(i) &&
+                widget.otpPinFieldStyle?.activeFieldBorderGradient != null
+            ? widget.otpPinFieldStyle!.activeFieldBorderGradient
+            : (pinsInputed[i].isNotEmpty &&
+                    widget.otpPinFieldStyle?.filledFieldBorderGradient != null)
+                ? widget.otpPinFieldStyle!.filledFieldBorderGradient
+                : widget.otpPinFieldStyle?.defaultFieldBorderGradient;
 
     if (widget.otpPinFieldDecoration ==
         OtpPinFieldDecoration.underlinedPinBoxDecoration) {
@@ -327,6 +338,7 @@ class OtpPinFieldState extends State<OtpPinField>
     } else if (widget.otpPinFieldDecoration ==
         OtpPinFieldDecoration.defaultPinBoxDecoration) {
       boxDecoration = BoxDecoration(
+          boxShadow: boxShadow,
           border: Border.all(
             color: fieldBorderColor,
             width: widget.otpPinFieldStyle!.fieldBorderWidth,
@@ -336,6 +348,8 @@ class OtpPinFieldState extends State<OtpPinField>
 
       if (fieldBorderGradient != null) {
         foregroundBoxDecoration = BoxDecoration(
+            boxShadow: boxShadow,
+            color: fieldBackgroundColor,
             border: GradientBoxBorder(
               gradient: fieldBorderGradient,
               width: widget.otpPinFieldStyle!.fieldBorderWidth,
@@ -345,6 +359,7 @@ class OtpPinFieldState extends State<OtpPinField>
     } else if (widget.otpPinFieldDecoration ==
         OtpPinFieldDecoration.roundedPinBoxDecoration) {
       boxDecoration = BoxDecoration(
+        boxShadow: boxShadow,
         border: Border.all(
           color: fieldBorderColor,
           width: widget.otpPinFieldStyle!.fieldBorderWidth,
@@ -354,6 +369,8 @@ class OtpPinFieldState extends State<OtpPinField>
       );
       if (fieldBorderGradient != null) {
         foregroundBoxDecoration = BoxDecoration(
+          boxShadow: boxShadow,
+          color: fieldBackgroundColor,
           border: GradientBoxBorder(
             gradient: fieldBorderGradient,
             width: widget.otpPinFieldStyle!.fieldBorderWidth,
@@ -363,6 +380,7 @@ class OtpPinFieldState extends State<OtpPinField>
       }
     } else {
       boxDecoration = BoxDecoration(
+          boxShadow: boxShadow,
           border: Border.all(
               color: fieldBorderColor,
               width: widget.otpPinFieldStyle!.fieldBorderWidth),
@@ -371,6 +389,8 @@ class OtpPinFieldState extends State<OtpPinField>
               widget.otpPinFieldStyle!.fieldBorderRadius));
       if (fieldBorderGradient != null) {
         foregroundBoxDecoration = BoxDecoration(
+            boxShadow: boxShadow,
+            color: fieldBackgroundColor,
             border: GradientBoxBorder(
               gradient: fieldBorderGradient,
               width: widget.otpPinFieldStyle!.fieldBorderWidth,
@@ -383,8 +403,12 @@ class OtpPinFieldState extends State<OtpPinField>
     return Container(
         width: widget.fieldWidth,
         alignment: Alignment.center,
-        foregroundDecoration: foregroundBoxDecoration,
-        decoration: boxDecoration,
+        foregroundDecoration: fieldBorderGradient != null && boxShadow != null
+            ? null
+            : foregroundBoxDecoration,
+        decoration: fieldBorderGradient != null && boxShadow != null
+            ? foregroundBoxDecoration
+            : boxDecoration,
         child: Stack(
           children: [
             Center(

--- a/lib/src/otp_pin_field_style.dart
+++ b/lib/src/otp_pin_field_style.dart
@@ -14,6 +14,9 @@ class OtpPinFieldStyle {
   final Gradient? activeFieldBorderGradient;
   final Gradient? filledFieldBorderGradient;
   final Gradient? defaultFieldBorderGradient;
+  final List<BoxShadow>? activeFieldBoxShadow;
+  final List<BoxShadow>? filledFieldBoxShadow;
+  final List<BoxShadow>? defaultFieldBoxShadow;
 
   const OtpPinFieldStyle({
     this.textStyle = const TextStyle(fontSize: 18.0, color: Colors.black),
@@ -29,5 +32,8 @@ class OtpPinFieldStyle {
     this.fieldPadding = 10.0,
     this.fieldBorderRadius = 2.0,
     this.fieldBorderWidth = 2.0,
+    this.activeFieldBoxShadow,
+    this.filledFieldBoxShadow,
+    this.defaultFieldBoxShadow,
   });
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: otp_pin_field
 description: A flutter package which will help you to generate pin code fields with beautiful design and animations. Can be useful for OTP or pin code inputs.
-version: 1.2.7+1
+version: 1.2.8
 homepage: https://github.com/shivbo96/otp_pin_field
 
 environment:


### PR DESCRIPTION
This feature update introduces box border support for the `defaultPinBoxDecoration`, `roundedPinBoxDecoration`, and `custom` options within the `otpPinFieldDecoration`. The new functionality allows users to customize the appearance of their OTP pin fields with box borders, enhancing the visual flexibility of the widget.

**Changes:**
- Added box border support for:
  - `defaultPinBoxDecoration`
  - `roundedPinBoxDecoration`
  - `custom` decoration
- Note: The `underlinedPinBoxDecoration` does not include this box border support.

**Benefits:**
- Users can now apply consistent box borders to their OTP pin fields, improving the aesthetic appeal and customization options of the `otpPinField` widget.
