### PR TITLE
feat: Added hint text support and fixed autofocus behavior on web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,3 +163,18 @@ feat: Add support for custom border colors and width in OTP pin field
 
 **Documentation:**
 - Updated changelog file with version 1.2.9+1 release notes.
+
+
+#### [Version 1.3.0] - 2024-10-21
+
+**Added**
+- **Hint Text Support**: Added new properties to show hint text in the OTP pin field:
+  - `showHintText`: Allows displaying hint text inside the pin fields (default: `false`).
+  - `hintText`: Customizable hint text to display (default: `'0'`).
+  - `hintTextColor`: Customize the color of the hint text (default: `Colors.black45`).
+
+**Improvements:**
+- Added logic to respect `autoFillEnable` flag, ensuring that `autofillHints` is set to `null` when `autoFillEnable == false`. This prevents the SMS hint from being displayed when autofill is disabled.
+
+**Fixed**
+- Fixed autofocus behavior on the web. Autofocus is now correctly respected on web platforms if the `autoFocus` property is enabled.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Created by Shivam Mishra [@shivbo96](https://github.com/shivbo96)
 
 <a href="https://paypal.me/shivam131197" target="_blank"><img src="https://raw.githubusercontent.com/stefan-niedermann/paypal-donate-button/master/paypal-donate-button.png" width="174"></a>
 
-
 # Usage
 
 ## Use this package as a library
@@ -83,6 +82,9 @@ import 'package:otp_pin_field/otp_pin.dart';
 | defaultFieldBorderGradient  | Gradient                |                                                  | Set gradient border Color for unfocused/default field pin box.                                                                                                                                                                                  |
 | onPhoneHintSelected         | Function(String)        |                                                  | Callback when you select the autofill hints.                                                                                                                                                                                                    |
 | beforeTextPaste             | bool Function(String?)? | null                                             | This callback execute before you copy paste the OTP                                                                                                                                                                                             |
+| showHintText                | bool                    | false                                            | Bool to show hints in pin field or not                                                                                                                                                                                                          |
+| hintTextColor               | Color                   | Color.black45                                    | To set the color of hints in pin field or not                                                                                                                                                                                                   |
+| hintText                    | String                  | 0                                                | To set the text  of hints in pin field                                                                                                                                                                                                          |
 
 # Example
 
@@ -119,6 +121,16 @@ import 'package:otp_pin_field/otp_pin.dart';
 
             /// to decorate your Otp_Pin_Field
             otpPinFieldStyle: OtpPinFieldStyle(
+            
+              /// bool to show hints in pin field or not
+                showHintText: true,
+
+              /// to set the color of hints in pin field or not
+              // hintTextColor: Colors.red,
+
+              /// To set the text  of hints in pin field
+              // hintText: '1',
+                
               /// border color for inactive/unfocused Otp_Pin_Field
               // defaultFieldBorderColor: Colors.red,
 
@@ -218,20 +230,20 @@ refer to `example/lib/main.dart`
 
 #### Different Shapes
 
-<img src="https://raw.githubusercontent.com/shivbo96/otp_pin_field/main/images/1.png" width="250" height="480">
-<img src="https://raw.githubusercontent.com/shivbo96/otp_pin_field/main/images/2.png" width="250" height="480">
-<img src="https://raw.githubusercontent.com/shivbo96/otp_pin_field/main/images/3.png" width="250" height="480">
-<img src="https://raw.githubusercontent.com/shivbo96/otp_pin_field/main/images/4.png" width="250" height="480">
-<img src="https://raw.githubusercontent.com/shivbo96/otp_pin_field/main/images/5.png" width="250" height="480">
-<img src="https://raw.githubusercontent.com/shivbo96/otp_pin_field/main/images/6.png" width="250" height="480">
-<img src="https://raw.githubusercontent.com/shivbo96/otp_pin_field/main/images/7.png" width="250" height="480">
-<img src="https://raw.githubusercontent.com/shivbo96/otp_pin_field/main/images/8.png" width="250" height="480">
-<img src="https://raw.githubusercontent.com/shivbo96/otp_pin_field/main/images/9.png" width="250" height="480">
-<img src="https://raw.githubusercontent.com/shivbo96/otp_pin_field/main/images/10.png" width="250" height="480">
+<img src="https://raw.githubusercontent.com/shivbo96/otp_pin_field/main/images/1.png" width="250" height="480" alt="OTP Pin Field - Example 1">
+<img src="https://raw.githubusercontent.com/shivbo96/otp_pin_field/main/images/2.png" width="250" height="480" alt="OTP Pin Field - Example 2">
+<img src="https://raw.githubusercontent.com/shivbo96/otp_pin_field/main/images/3.png" width="250" height="480" alt="OTP Pin Field - Example 3">
+<img src="https://raw.githubusercontent.com/shivbo96/otp_pin_field/main/images/4.png" width="250" height="480" alt="OTP Pin Field - Example 4">
+<img src="https://raw.githubusercontent.com/shivbo96/otp_pin_field/main/images/5.png" width="250" height="480" alt="OTP Pin Field - Example 5">
+<img src="https://raw.githubusercontent.com/shivbo96/otp_pin_field/main/images/6.png" width="250" height="480" alt="OTP Pin Field - Example 6">
+<img src="https://raw.githubusercontent.com/shivbo96/otp_pin_field/main/images/7.png" width="250" height="480" alt="OTP Pin Field - Example 7">
+<img src="https://raw.githubusercontent.com/shivbo96/otp_pin_field/main/images/8.png" width="250" height="480" alt="OTP Pin Field - Example 8">
+<img src="https://raw.githubusercontent.com/shivbo96/otp_pin_field/main/images/9.png" width="250" height="480" alt="OTP Pin Field - Example 9">
+<img src="https://raw.githubusercontent.com/shivbo96/otp_pin_field/main/images/10.png" width="250" height="480" alt="OTP Pin Field - Example 10">
 
 ### video
 
-<img width="250" height="480" src="https://user-images.githubusercontent.com/37922543/233455524-43332b0b-c315-46f8-b4bf-8a64e1786108.gif" />
+<img width="250" height="480" src="https://user-images.githubusercontent.com/37922543/233455524-43332b0b-c315-46f8-b4bf-8a64e1786108.gif" alt="Animated OTP Pin Field Example" />
 
 ## More information
 

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Flutter
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,34 +1,40 @@
 import 'package:example_otp_pin_field/next_page.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:otp_pin_field/otp_pin_field.dart';
 
 void main() {
-  runApp(MyApp());
+  runApp(const MyApp());
 }
 
 class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Demo',
-      // debugShowMaterialGrid: false,
       debugShowCheckedModeBanner: false,
       theme: ThemeData(
         primarySwatch: Colors.blue,
         visualDensity: VisualDensity.adaptivePlatformDensity,
       ),
-      home: MyHomePage(title: 'Flutter Demo Home Page'),
+      home: const MyHomePage(title: 'Flutter Demo Home Page'),
     );
   }
 }
 
 class MyHomePage extends StatefulWidget {
-  MyHomePage({Key? key, required this.title}) : super(key: key);
+  const MyHomePage({super.key, required this.title});
 
   final String title;
 
   @override
-  _MyHomePageState createState() => _MyHomePageState();
+  State<MyHomePage> createState() => _MyHomePageState();
+}
+
+void _hideKeyboard() {
+  SystemChannels.textInput.invokeMethod('TextInput.hide');
 }
 
 class _MyHomePageState extends State<MyHomePage> {
@@ -38,7 +44,7 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: hideKeyboard,
+      onTap: () => _hideKeyboard(),
       child: Scaffold(
         appBar: AppBar(title: Text(widget.title)),
         body: Column(
@@ -56,21 +62,30 @@ class _MyHomePageState extends State<MyHomePage> {
               ///in case you want to change the action of keyboard
               /// to clear the Otp pin Controller
               onSubmit: (text) {
-                print('Entered pin is $text');
+                debugPrint('Entered pin is $text');
 
                 /// return the entered pin
               },
               onChange: (text) {
-                print('Enter on change pin is $text');
+                debugPrint('Enter on change pin is $text');
 
                 /// return the entered pin
               },
               onCodeChanged: (code) {
-                print('onCodeChanged  is $code');
+                debugPrint('onCodeChanged  is $code');
               },
 
               /// to decorate your Otp_Pin_Field
-              otpPinFieldStyle: OtpPinFieldStyle(
+              otpPinFieldStyle: const OtpPinFieldStyle(
+                /// bool to show hints in pin field or not
+                showHintText: true,
+
+                /// to set the color of hints in pin field or not
+                // hintTextColor: Colors.red,
+
+                /// to set the text  of hints in pin field
+                // hintText: '1',
+
                 /// border color for inactive/unfocused Otp_Pin_Field
                 // defaultFieldBorderColor: Colors.red,
 
@@ -107,7 +122,7 @@ class _MyHomePageState extends State<MyHomePage> {
               cursorColor: Colors.indigo,
 
               /// to choose cursor color
-              upperChild: Column(
+              upperChild: const Column(
                 children: [
                   SizedBox(height: 30),
                   Icon(Icons.flutter_dash_outlined, size: 150),
@@ -117,19 +132,19 @@ class _MyHomePageState extends State<MyHomePage> {
               // 123456
               middleChild: Column(
                 children: [
-                  SizedBox(height: 30),
+                  const SizedBox(height: 30),
                   ElevatedButton(
                       onPressed: () {
                         _otpPinFieldController.currentState
                             ?.clearOtp(); // clear controller
                       },
-                      child: Text('clear OTP')),
-                  SizedBox(height: 10),
+                      child: const Text('clear OTP')),
+                  const SizedBox(height: 10),
                   ElevatedButton(
                       onPressed: () => Navigator.push(context,
                           MaterialPageRoute(builder: (context) => NextPage())),
-                      child: Text('Next Class')),
-                  SizedBox(height: 30),
+                      child: const Text('Next Class')),
+                  const SizedBox(height: 30),
                 ],
               ),
 

--- a/example/lib/next_page.dart
+++ b/example/lib/next_page.dart
@@ -1,14 +1,14 @@
 import 'package:flutter/material.dart';
 
 class NextPage extends StatelessWidget {
+  const NextPage({super.key});
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(),
-      body: Container(
-        child: Center(
-          child: Text('Next Page '),
-        ),
+      body: const Center(
+        child: Text('Next Page '),
       ),
     );
   }

--- a/lib/otp_pin_field_method_channel.dart
+++ b/lib/otp_pin_field_method_channel.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 import 'otp_pin_field_platform_interface.dart';
@@ -6,7 +5,7 @@ import 'otp_pin_field_platform_interface.dart';
 /// An implementation of [OtpPinFieldPlatform] that uses method channels.
 class MethodChannelOtpPinField extends OtpPinFieldPlatform {
   /// The method channel used to interact with the native platform.
-  @visibleForTesting
+  /// @visibleForTesting
   final methodChannel = const MethodChannel('otp_pin_field');
 
   @override

--- a/lib/src/otp_pin_field_state.dart
+++ b/lib/src/otp_pin_field_state.dart
@@ -98,9 +98,11 @@ class OtpPinFieldState extends State<OtpPinField>
                     child: TextField(
                       controller: controller,
                       maxLength: widget.maxLength,
-                      autofillHints: const [AutofillHints.oneTimeCode],
+                      autofillHints: (widget.autoFillEnable ?? false)
+                          ? const [AutofillHints.oneTimeCode]
+                          : null,
                       readOnly: widget.showCustomKeyboard ?? true,
-                      autofocus: !kIsWeb ? widget.autoFocus : false,
+                      autofocus: widget.autoFocus,
                       enableInteractiveSelection: false,
                       inputFormatters:
                           widget.keyboardType == TextInputType.number
@@ -194,9 +196,11 @@ class OtpPinFieldState extends State<OtpPinField>
               child: TextField(
                 controller: controller,
                 maxLength: widget.maxLength,
-                autofillHints: const [AutofillHints.oneTimeCode],
+                autofillHints: (widget.autoFillEnable ?? false)
+                    ? const [AutofillHints.oneTimeCode]
+                    : null,
                 readOnly: !(widget.showDefaultKeyboard ?? true),
-                autofocus: !kIsWeb ? widget.autoFocus : false,
+                autofocus: widget.autoFocus,
                 enableInteractiveSelection: false,
                 inputFormatters: widget.keyboardType == TextInputType.number
                     ? <TextInputFormatter>[
@@ -383,7 +387,11 @@ class OtpPinFieldState extends State<OtpPinField>
             Center(
               child: Text(
                 _getPinDisplay(i),
-                style: widget.otpPinFieldStyle?.textStyle,
+                style: pinsInputed[i].isEmpty &&
+                        widget.otpPinFieldStyle?.showHintText == true
+                    ? widget.otpPinFieldStyle?.textStyle
+                        .copyWith(color: widget.otpPinFieldStyle?.hintTextColor)
+                    : widget.otpPinFieldStyle?.textStyle,
                 textAlign: TextAlign.center,
               ),
             ),
@@ -405,6 +413,11 @@ class OtpPinFieldState extends State<OtpPinField>
         display = value;
         break;
     }
+
+    if (value.isEmpty && widget.otpPinFieldStyle?.showHintText == true) {
+      return widget.otpPinFieldStyle?.hintText ?? '0';
+    }
+
     return value.isNotEmpty ? display : value;
   }
 
@@ -514,7 +527,7 @@ class OtpPinFieldState extends State<OtpPinField>
       if (ending) {
         widget.onSubmit(controller.text.trim());
         FocusScope.of(context).unfocus();
-        hideKeyboard();
+        _hideKeyboard();
       }
     }
   }
@@ -605,4 +618,8 @@ mixin OtpPinAutoFill {
   }
 
   void codeUpdated();
+}
+
+void _hideKeyboard() {
+  SystemChannels.textInput.invokeMethod('TextInput.hide');
 }

--- a/lib/src/otp_pin_field_style.dart
+++ b/lib/src/otp_pin_field_style.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 
 class OtpPinFieldStyle {
   final TextStyle textStyle;
+  final bool showHintText;
+  final String hintText;
+  final Color hintTextColor;
   final double fieldPadding;
   final Color activeFieldBackgroundColor;
   final Color defaultFieldBackgroundColor;
@@ -19,7 +22,10 @@ class OtpPinFieldStyle {
   final List<BoxShadow>? defaultFieldBoxShadow;
 
   const OtpPinFieldStyle({
-    this.textStyle = const TextStyle(fontSize: 18.0, color: Colors.black),
+    this.textStyle = const TextStyle(fontSize: 22.0, color: Colors.black),
+    this.showHintText = false,
+    this.hintText = '0',
+    this.hintTextColor = Colors.black45,
     this.activeFieldBorderColor = Colors.black,
     this.defaultFieldBorderColor = Colors.black45,
     this.activeFieldBackgroundColor = Colors.transparent,

--- a/lib/src/otp_pin_field_widget.dart
+++ b/lib/src/otp_pin_field_widget.dart
@@ -35,44 +35,41 @@ class OtpPinField extends StatefulWidget {
   final bool Function(String? text)? beforeTextPaste;
   final Function(String?)? onPhoneHintSelected;
 
-  const OtpPinField(
-      {super.key,
-      this.fieldHeight = 50.0,
-      this.fieldWidth = 50.0,
-      this.maxLength = 4,
-      this.onCodeChanged,
-      this.otpPinFieldStyle = const OtpPinFieldStyle(),
-      this.textInputAction = TextInputAction.done,
-      this.otpPinFieldInputType = OtpPinFieldInputType.none,
-      this.otpPinFieldDecoration =
-          OtpPinFieldDecoration.underlinedPinBoxDecoration,
-      this.otpPinInputCustom = '*',
-      this.smsRegex,
-      this.beforeTextPaste,
-      required this.onSubmit,
-      required this.onChange,
-      this.keyboardType = TextInputType.number,
-      this.autoFocus = true,
-      this.autoFillEnable = false,
-      this.phoneNumbersHint = false,
-      this.highlightBorder = true,
-      this.showCursor = true,
-      this.cursorColor,
-      this.cursorWidth = 2,
-      this.mainAxisAlignment,
-      this.upperChild,
-      this.middleChild,
-      this.customKeyboard,
-      this.showCustomKeyboard,
-      this.onPhoneHintSelected,
-      this.showDefaultKeyboard = true});
+  const OtpPinField({
+    super.key,
+    this.fieldHeight = 50.0,
+    this.fieldWidth = 50.0,
+    this.maxLength = 4,
+    this.onCodeChanged,
+    this.otpPinFieldStyle = const OtpPinFieldStyle(),
+    this.textInputAction = TextInputAction.done,
+    this.otpPinFieldInputType = OtpPinFieldInputType.none,
+    this.otpPinFieldDecoration =
+        OtpPinFieldDecoration.underlinedPinBoxDecoration,
+    this.otpPinInputCustom = '*',
+    this.smsRegex,
+    this.beforeTextPaste,
+    required this.onSubmit,
+    required this.onChange,
+    this.keyboardType = TextInputType.number,
+    this.autoFocus = true,
+    this.autoFillEnable = false,
+    this.phoneNumbersHint = false,
+    this.highlightBorder = true,
+    this.showCursor = true,
+    this.cursorColor,
+    this.cursorWidth = 2,
+    this.mainAxisAlignment,
+    this.upperChild,
+    this.middleChild,
+    this.customKeyboard,
+    this.showCustomKeyboard,
+    this.onPhoneHintSelected,
+    this.showDefaultKeyboard = true,
+  });
 
   @override
   State<StatefulWidget> createState() {
     return OtpPinFieldState();
   }
-}
-
-void hideKeyboard() {
-  SystemChannels.textInput.invokeMethod('TextInput.hide');
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: otp_pin_field
 description: A flutter package which will help you to generate pin code fields with beautiful design and animations. Can be useful for OTP or pin code inputs.
-version: 1.2.9+1
+version: 1.3.0
 homepage: https://github.com/shivbo96/otp_pin_field
 
 environment:


### PR DESCRIPTION
feat: Added hint text support and fixed autofocus behavior on web

- Added new properties for hint text in OTP pin field:
  - showHintText (default: false)
  - hintText (default: '0')
  - hintTextColor (default: Colors.black45)
  
- Respected autoFillEnable flag to prevent SMS hint when autofill is disabled.
- Fixed autofocus behavior on the web to respect the autoFocus property.