### PR TITLE
Add unFocusOnEnding option to OtpPinField 

### DIFF
--- a/lib/src/otp_pin_field_state.dart
+++ b/lib/src/otp_pin_field_state.dart
@@ -125,7 +125,9 @@ class OtpPinFieldState extends State<OtpPinField>
                         ending = text.length == widget.maxLength;
                         if (ending) {
                           widget.onSubmit(text);
-                          FocusScope.of(context).unfocus();
+                          if (widget.unFocusOnEnding) {
+                            FocusScope.of(context).unfocus();
+                          }
                         }
                       },
                     ),
@@ -150,7 +152,7 @@ class OtpPinFieldState extends State<OtpPinField>
                       widget.onChange(controller.text.trim());
                       ending =
                           controller.text.trim().length == widget.maxLength;
-                      if (ending) {
+                      if (ending && widget.unFocusOnEnding) {
                         FocusScope.of(context).unfocus();
                       }
                     },
@@ -223,7 +225,9 @@ class OtpPinFieldState extends State<OtpPinField>
                   ending = text.length == widget.maxLength;
                   if (ending) {
                     widget.onSubmit(text);
-                    FocusScope.of(context).unfocus();
+                    if (widget.unFocusOnEnding) {
+                      FocusScope.of(context).unfocus();
+                    }
                   }
                 },
               ),
@@ -526,8 +530,10 @@ class OtpPinFieldState extends State<OtpPinField>
       ending = controller.text.trim().length == widget.maxLength;
       if (ending) {
         widget.onSubmit(controller.text.trim());
-        FocusScope.of(context).unfocus();
-        _hideKeyboard();
+        if (widget.unFocusOnEnding) {
+          FocusScope.of(context).unfocus();
+          _hideKeyboard();
+        }
       }
     }
   }

--- a/lib/src/otp_pin_field_widget.dart
+++ b/lib/src/otp_pin_field_widget.dart
@@ -30,6 +30,7 @@ class OtpPinField extends StatefulWidget {
   final Widget? customKeyboard;
   final bool? showCustomKeyboard;
   final bool? showDefaultKeyboard;
+  final bool unFocusOnEnding;
   final Function(String)? onCodeChanged;
   final bool Function(String? text)? beforeTextPaste;
   final Function(String?)? onPhoneHintSelected;
@@ -65,6 +66,7 @@ class OtpPinField extends StatefulWidget {
     this.showCustomKeyboard,
     this.onPhoneHintSelected,
     this.showDefaultKeyboard = true,
+    this.unFocusOnEnding = false,
   });
 
   @override


### PR DESCRIPTION
Changing textInput action to 'next' doesn't work. I added unFocusOnEnding parameter to not doing unFocus when not wanted