### PR TITLE
Feature/enable paste overlay to appear on long or double press

### DIFF
--- a/lib/src/otp_pin_field_state.dart
+++ b/lib/src/otp_pin_field_state.dart
@@ -205,7 +205,11 @@ class OtpPinFieldState extends State<OtpPinField>
             ),
             // Transparent TextField overlay
             Positioned.fill(
-              child: TextField(
+              child:
+              Padding(
+                padding: const EdgeInsets.only(bottom: 10, left: 70),
+                child:
+              TextField(
                 cursorColor: Colors.transparent,
                 controller: controller,
                 maxLength: widget.maxLength,
@@ -224,7 +228,7 @@ class OtpPinFieldState extends State<OtpPinField>
                 keyboardType: widget.keyboardType,
                 textInputAction: widget.textInputAction,
                 style: const TextStyle(
-                    color: Colors.transparent), // Make text invisible
+                    color: Colors.transparent,), // Make text invisible
                 decoration: const InputDecoration(
                   counterText: '', // Remove counter text
                   border: InputBorder.none, // Remove borders
@@ -248,6 +252,7 @@ class OtpPinFieldState extends State<OtpPinField>
                     }
                   }
                 },
+              ),
               ),
             ),
           ],

--- a/lib/src/otp_pin_field_state.dart
+++ b/lib/src/otp_pin_field_state.dart
@@ -226,6 +226,7 @@ class OtpPinFieldState extends State<OtpPinField>
                 style: const TextStyle(
                     color: Colors.transparent), // Make text invisible
                 decoration: const InputDecoration(
+                  counterText: '', // Remove counter text
                   border: InputBorder.none, // Remove borders
                   contentPadding: EdgeInsets.zero, // Remove padding
                 ),

--- a/lib/src/otp_pin_field_state.dart
+++ b/lib/src/otp_pin_field_state.dart
@@ -87,23 +87,25 @@ class OtpPinFieldState extends State<OtpPinField>
             onTap: onFieldFocus,
             child: SizedBox(
               height: widget.fieldHeight,
-              child: Stack(children: [
-                Row(
+              child: Stack(
+                children: [
+                  // Custom pin fields
+                  Row(
                     mainAxisAlignment:
                         widget.mainAxisAlignment ?? MainAxisAlignment.center,
-                    children: _buildBody(context)),
-                AbsorbPointer(
-                  child: Opacity(
-                    opacity: 0.0,
+                    children: _buildBody(context),
+                  ),
+                  // Transparent TextField overlay
+                  Positioned.fill(
                     child: TextField(
                       controller: controller,
                       maxLength: widget.maxLength,
                       autofillHints: (widget.autoFillEnable ?? false)
                           ? const [AutofillHints.oneTimeCode]
                           : null,
-                      readOnly: widget.showCustomKeyboard ?? true,
+                      readOnly: !(widget.showDefaultKeyboard ?? true),
                       autofocus: widget.autoFocus,
-                      enableInteractiveSelection: false,
+                      enableInteractiveSelection: true, // Enable paste overlay
                       inputFormatters:
                           widget.keyboardType == TextInputType.number
                               ? <TextInputFormatter>[
@@ -112,6 +114,13 @@ class OtpPinFieldState extends State<OtpPinField>
                               : null,
                       focusNode: _focusNode,
                       keyboardType: widget.keyboardType,
+                      textInputAction: widget.textInputAction,
+                      style: TextStyle(
+                          color: Colors.transparent), // Make text invisible
+                      decoration: InputDecoration(
+                        border: InputBorder.none, // Remove borders
+                        contentPadding: EdgeInsets.zero, // Remove padding
+                      ),
                       onSubmitted: (text) {
                         debugPrint(text);
                       },
@@ -132,8 +141,8 @@ class OtpPinFieldState extends State<OtpPinField>
                       },
                     ),
                   ),
-                )
-              ]),
+                ],
+              ),
             ),
           ),
           Expanded(child: widget.middleChild ?? const SizedBox.shrink()),
@@ -186,16 +195,18 @@ class OtpPinFieldState extends State<OtpPinField>
       onTap: onFieldFocus,
       child: SizedBox(
         height: widget.fieldHeight,
-        child: Stack(children: [
-          Row(
+        child: Stack(
+          children: [
+            // Custom pin fields
+            Row(
               mainAxisAlignment:
                   widget.mainAxisAlignment ?? MainAxisAlignment.center,
-              children: _buildBody(context)),
-          AbsorbPointer(
-            absorbing: true,
-            child: Opacity(
-              opacity: 0.0,
+              children: _buildBody(context),
+            ),
+            // Transparent TextField overlay
+            Positioned.fill(
               child: TextField(
+                cursorColor: Colors.transparent,
                 controller: controller,
                 maxLength: widget.maxLength,
                 autofillHints: (widget.autoFillEnable ?? false)
@@ -203,15 +214,21 @@ class OtpPinFieldState extends State<OtpPinField>
                     : null,
                 readOnly: !(widget.showDefaultKeyboard ?? true),
                 autofocus: widget.autoFocus,
-                enableInteractiveSelection: false,
+                enableInteractiveSelection: true, // Enable paste overlay
                 inputFormatters: widget.keyboardType == TextInputType.number
                     ? <TextInputFormatter>[
                         FilteringTextInputFormatter.digitsOnly
                       ]
                     : null,
                 focusNode: _focusNode,
-                textInputAction: widget.textInputAction,
                 keyboardType: widget.keyboardType,
+                textInputAction: widget.textInputAction,
+                style: const TextStyle(
+                    color: Colors.transparent), // Make text invisible
+                decoration: const InputDecoration(
+                  border: InputBorder.none, // Remove borders
+                  contentPadding: EdgeInsets.zero, // Remove padding
+                ),
                 onSubmitted: (text) {
                   debugPrint(text);
                 },
@@ -232,8 +249,8 @@ class OtpPinFieldState extends State<OtpPinField>
                 },
               ),
             ),
-          )
-        ]),
+          ],
+        ),
       ),
     );
   }

--- a/lib/src/otp_pin_field_state.dart
+++ b/lib/src/otp_pin_field_state.dart
@@ -118,6 +118,7 @@ class OtpPinFieldState extends State<OtpPinField>
                       style: TextStyle(
                           color: Colors.transparent), // Make text invisible
                       decoration: InputDecoration(
+                        counterText: '', // Remove counter text
                         border: InputBorder.none, // Remove borders
                         contentPadding: EdgeInsets.zero, // Remove padding
                       ),


### PR DESCRIPTION
I got a client request to enable long tap or double tabs show overlay with "paste" like normal text fields so it's implemented
* padding for make overlay appear on first pin position