### PR TITLE
fix(ios): resolve SwiftPM library product name mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,3 +260,7 @@ Updated:
 - **iOS SwiftPM Build Fix**:
     - Removed the invalid remote dependency on `flutter/packages` in `Package.swift` that was causing SwiftPM dependency resolution failure.
 
+## [1.5.2] - 2026-07-19
+
+- **iOS SwiftPM Product Name Fix**:
+    - Renamed the library product name in `Package.swift` from `otp_pin_field` to `otp-pin-field` (with hyphens) to align with Flutter's package product name generation.

--- a/ios/otp_pin_field.podspec
+++ b/ios/otp_pin_field.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'otp_pin_field'
-  s.version          = '1.5.1'
+  s.version          = '1.5.2'
   s.summary          = 'A new Flutter project.'
   s.description      = <<-DESC
 A new Flutter project.

--- a/ios/otp_pin_field/Package.swift
+++ b/ios/otp_pin_field/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     ],
     products: [
         .library(
-            name: "otp_pin_field",
+            name: "otp-pin-field",
             targets: ["otp_pin_field"]
         )
     ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: otp_pin_field
 description: A flutter package which will help you to generate pin code fields with beautiful design and animations. Can be useful for OTP or pin code inputs.
-version: 1.5.1
+version: 1.5.2
 repository: https://github.com/shivbo96/otp_pin_field
 homepage: https://www.techaheadcorp.com/
 


### PR DESCRIPTION
## Description
This PR resolves the Xcode SwiftPM dependency resolution error where the target product 'otp-pin-field' is not found.
## Changes Made
- Renamed the library product name in \`Package.swift\` from \`otp_pin_field\` to \`otp-pin-field\` (with hyphens) to align with Flutter's generated package product name mapping (underscores are replaced with hyphens for CFBundleIdentifier compatibility).
- Bumped version in \`pubspec.yaml\` to \`1.5.2\`.
- Bumped version in \`ios/otp_pin_field.podspec\` to \`1.5.2\` to maintain version alignment.
- Documented changes in \`CHANGELOG.md\` under version \`1.5.2\`.
## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Infrastructure/DevOps changes
- [ ] Documentation update
## Deployment Notes
- [x] No special deployment steps required
- [ ] Requires database migration
- [ ] Requires environment variable changes
- [ ] Requires infrastructure changes